### PR TITLE
fix: n seq data default 0

### DIFF
--- a/streamsight/settings/sliding_window_setting.py
+++ b/streamsight/settings/sliding_window_setting.py
@@ -57,7 +57,7 @@ class SlidingWindowSetting(Setting):
         self,
         background_t: int,
         window_size: int = np.iinfo(np.int32).max,  # in seconds
-        n_seq_data: int = 10,
+        n_seq_data: int = 0,
         top_K: int = 10,
         t_upper: int = np.iinfo(np.int32).max,
         t_ground_truth_window: Optional[int] = None,


### PR DESCRIPTION
## 🚨 Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #57 

## 🚀 Solution
<!-- How did you solve the problem? -->

🐛 **Bug Fixes**:

- `n_seq_data` defaults to 0